### PR TITLE
Использовать относительные пути к файлам вместо абсолютных

### DIFF
--- a/N-PLS.ipynb
+++ b/N-PLS.ipynb
@@ -111,8 +111,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Xdata_numpy = pkl.load(open('C:/Users/admin/Desktop/PLS_continue_2020/X.pkl.gz', 'rb'))\n",
-    "Ydata = pkl.load(open('C:/Users/admin/Desktop/PLS_continue_2020/y.pkl.gz', 'rb'))"
+    "Xdata_numpy = pkl.load(open('X.pkl.gz', 'rb'))\n",
+    "Ydata = pkl.load(open('y.pkl.gz', 'rb'))"
    ]
   },
   {


### PR DESCRIPTION
Абсолютные пути сильно затрудняют использование того же файла `*.ipynb` на всех компьютерах, кроме машины его создателя. Их стоит заменить на относительные, либо другим способом определять путь расположения файла `*.ipynb` и отсчитывать пути к `*.pkl.gz` от него.